### PR TITLE
Update `ServerType` Enum

### DIFF
--- a/corkus/objects/base_server.py
+++ b/corkus/objects/base_server.py
@@ -9,10 +9,11 @@ if TYPE_CHECKING:
 
 class ServerType(Enum):
     """Type of :py:class:`Server`."""
-    REGULAR = "WC"
+
+    REGULAR = "REGULAR"
     """Regular Wynncraft servers."""
 
-    YOUTUBE = "YT"
+    MEDIA = "MEDIA"
     """Servers restricted to players with :py:attr:`PlayerRank.MEDIA` rank."""
 
     OTHER = "OTHER"
@@ -36,7 +37,7 @@ class BaseServer(CorkusBase):
         if self.name.startswith("WC"):
             return ServerType.REGULAR
         elif self.name.startswith("YT"):
-            return ServerType.YOUTUBE
+            return ServerType.MEDIA
         else:
             return ServerType.OTHER
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -21,7 +21,7 @@ class TestNetwork(unittest.IsolatedAsyncioTestCase):
         self.assertGreater(sum([s.total_players for s in response.servers]), 0)
         self.assertTrue(any(s.name.startswith("WC") for s in response.servers))
         self.assertTrue(any(s.type == ServerType.REGULAR for s in response.servers))
-        self.assertTrue(any(s.type == ServerType.YOUTUBE for s in response.servers))
+        self.assertTrue(any(s.type == ServerType.MEDIA for s in response.servers))
         self.assertFalse(any(s.type == ServerType.OTHER for s in response.servers))
         self.assertGreater(len(response.players), 100)
         self.assertGreater(len(response.regular_players), 100)


### PR DESCRIPTION
This PR updates [ServerType](https://corkuspy.readthedocs.io/en/latest/code_overview/objects/server_type.html) Enum.

- Value of `ServerType.REGULAR`  has been changed from `WC` to `REGULAR`
- `ServerType.YOUTUBE` is now `ServerType.MEDIA` and value has been changed from `YT` to `MEDIA`

This is a breaking change that will be merged for release `2.0.0`