### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/corkus/objects/item.py
+++ b/corkus/objects/item.py
@@ -300,9 +300,9 @@ class Item(CorkusBase):
         """Minecraft `block`_/`item`_ ID + optional `data value`_,
         pre-flattening. Format: ``ID:DV``
 
-        .. _block: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Pre-flattening/Block_IDs
-        .. _item: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Pre-flattening/Item_IDs
-        .. _data value: https://minecraft.fandom.com/wiki/Java_Edition_data_values/Pre-flattening"""
+        .. _block: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening/Block_IDs
+        .. _item: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening/Item_IDs
+        .. _data value: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening"""
         if self.skin is not None:
             return "397:3"
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki